### PR TITLE
Missing path.

### DIFF
--- a/src/nhl_pipeline/utils/time_travel_validator.py
+++ b/src/nhl_pipeline/utils/time_travel_validator.py
@@ -328,6 +328,9 @@ def main():
         from cryptography.hazmat.backends import default_backend
         from cryptography.hazmat.primitives import serialization
         
+        # Expand ~ to home directory
+        private_key_path = os.path.expanduser(private_key_path)
+        
         with open(private_key_path, 'rb') as key_file:
             p_key = serialization.load_pem_private_key(
                 key_file.read(),


### PR DESCRIPTION
This pull request makes a minor improvement to the handling of file paths for private keys in the `main` function of `src/nhl_pipeline/utils/time_travel_validator.py`. The change ensures that paths using `~` are correctly expanded to the user's home directory before opening the file.

* Expand `~` to the home directory for `private_key_path` before reading the file, improving compatibility with user-supplied paths.