### PR TITLE
trying to fix dbt call from ingestion.

### DIFF
--- a/dags/nhl_daily_ingestion_dag.py
+++ b/dags/nhl_daily_ingestion_dag.py
@@ -202,7 +202,7 @@ with DAG(
         task_id="run_dbt_models",
         bash_command="""
             cd /usr/local/airflow/dags/dbt_nhl && \
-            dbt run --profiles-dir . --target prod
+            python3 -m dbt run --profiles-dir . --target prod
         """,
         env={
             "SNOWFLAKE_ACCOUNT": "{{ var.value.SNOWFLAKE_ACCOUNT }}",

--- a/dags/nhl_odds_daily_ingestion.py
+++ b/dags/nhl_odds_daily_ingestion.py
@@ -286,7 +286,7 @@ with DAG(
         task_id="run_dbt_odds_models",
         bash_command="""
             cd /usr/local/airflow/dags/dbt_nhl && \
-            dbt run --profiles-dir . --target prod --select tag:odds
+            python3 -m dbt run --profiles-dir . --target prod --select tag:odds
         """,
         env={
             "SNOWFLAKE_ACCOUNT": "{{ var.value.SNOWFLAKE_ACCOUNT }}",


### PR DESCRIPTION
This pull request introduces improvements to the NHL player props ingestion and modeling pipeline, mainly focusing on more robust player name matching and enhanced integration of team context. The changes improve the reliability of mapping odds provider player names to official NHL player IDs, especially for players who haven't played in the current season but have recent activity. Additionally, the DBT command invocation has been updated in Airflow DAGs for better compatibility.

**Player name matching and crosswalk enhancements:**

* Added a `recent_players` CTE in `fact_player_sog_props_v2.sql` to include players from the last 6 months, ensuring a comprehensive roster even for players not active this season.
* Introduced an `enhanced_crosswalk` CTE that matches odds provider player names to NHL player IDs using exact, normalized, and fuzzy logic, with confidence scoring and team context, preferring recent and team-aligned matches.
* Updated the join logic to use the enhanced crosswalk, assigning player IDs and names to odds data with improved accuracy.

**Team context and match data improvements:**

* In the final `joined` CTE, now uses matched player information from the enhanced crosswalk for pregame data, and overrides with actual game data postgame when available, ensuring accurate team and player attribution.

**Airflow DAG compatibility:**

* Changed the DBT command invocation in both `nhl_daily_ingestion_dag.py` and `nhl_odds_daily_ingestion.py` to use `python3 -m dbt` instead of directly calling `dbt`, improving compatibility with certain deployment environments. [[1]](diffhunk://#diff-3a34d590ac5c391a9c36d839fb020fff9b8001efec665dcdf282412562c82b8aL205-R205) [[2]](diffhunk://#diff-67a091924a07c6f969a85d7e7b93a84d629c2c1b2c2f26d615b323bd1cfb45b5L289-R289)